### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Installation & Usage (Mac OS X 10.8)
 8. Now type **./relaymyhome full** and you should see the script do its thing. If you get an error that stops the script, something went wrong. The script takes about 8 minutes to run, after which you should have a list full of StreetPass hits on your 3DS.
 9. Once you have greeted your new visitors in the StreetPass Plaza, you can run the script again to get another batch of StreetPasses. You should be able to run the script many times before you will need to wait for the eight hour cooldown on hitting the same relay twice.
 
+Installation & Usage (Mac OS X 10.9)
+====================================
+1. Download the script file from this page. The easy way is to download the ZIP file using the "Download ZIP" button on the bottom right of this page. Double click the downloaded file to unzip it.
+2. Move the **relaymyhome** file to somewhere you can access (if you're completely unfamiliar with using the OSX Terminal, stick it in **Documents**).
+3. Open **System Preferences**, then select **Sharing**. Select **Internet Sharing**, then set "Share your connection from:" to **Ethernet**, and check off **WiFi** in the "To computers using" box. Click the **Wi-Fi Options** button, enter **attwifi** as the Network Name, leave Channel default and ensure Security is set to **None**. Finally, check off **Internet Sharing** and click **Start** at the prompt.
+4. Open **Terminal** (in your Applications folder under *Utilities*), and navigate to the location you placed **relaymyhome** -- if you put it in **Documents**, then in *Terminal* type: **cd ~/Documents**
+5. If this is the first time you are running the script, in Terminal enter the command: **chmod +x relaymyhome**
+6. Now type **./relaymyhome full** and you should see the script do its thing. If you get an error that stops the script, something went wrong. The script takes about 8 minutes to run, after which you should have a list full of StreetPass hits on your 3DS.
+7. Once you have greeted your new visitors in the StreetPass Plaza, you can run the script again to get another batch of StreetPasses. You should be able to run the script many times before you will need to wait for the eight hour cooldown on hitting the same relay twice.
+
 Credits
 =======
 All credit for the original idea of duplicating StreetPass Relays goes to the many folks [listed here](https://docs.google.com/spreadsheet/lv?key=0AvvH5W4E2lIwdEFCUkxrM085ZGp0UkZlenp6SkJablE&f=true&noheader=true&gid=0). All I've done is automated the process that they discovered.


### PR DESCRIPTION
OS X 10.9 uses computer name by default as the SSID, regardless of what you enter in "Create Network" so the steps differ slightly.
